### PR TITLE
Modify loader to update ISSNs that do not have pubType

### DIFF
--- a/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/BatchJournalFinder.java
+++ b/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/BatchJournalFinder.java
@@ -105,9 +105,10 @@ public class BatchJournalFinder implements JournalFinder {
 
     @Override
     public synchronized Journal byIssn(String issn) {
-        if (issnMap.containsKey(issn)) {
+        String id = getUriByIssn(issn);
+        if (id != null) {
             final Journal j = new Journal();
-            j.setId(URI.create(issnMap.get(issn)));
+            j.setId(URI.create(id));
             if (typeARefs.contains(j.getId().toString())) {
                 j.setPmcParticipation(PmcParticipation.A);
             }
@@ -115,6 +116,21 @@ public class BatchJournalFinder implements JournalFinder {
         }
 
         return null;
+    }
+    
+    private String getUriByIssn(String issn) {
+        if (issnMap.containsKey(issn)) {
+            return issnMap.get(issn);
+        }
+        
+        String[] parts = issn.split(":");
+        
+        if (parts.length == 2) {
+            return issnMap.get(parts[1]);
+        }
+        
+        return null;
+        
     }
 
     static CloseableHttpClient getHttpClient() {

--- a/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/NihTypeAReader.java
+++ b/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/NihTypeAReader.java
@@ -57,7 +57,7 @@ public class NihTypeAReader implements JournalReader {
 
         LOG.debug("Parsing CSV record..");
 
-        final Journal j = new Journal();
+        final Journal j = new PMCSource();
 
         try {
 

--- a/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/PMCSource.java
+++ b/pass-journal-loader-nih/src/main/java/org/dataconservancy/pass/loader/journal/nih/PMCSource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Johns Hopkins University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dataconservancy.pass.loader.journal.nih;
+
+import org.dataconservancy.pass.model.Journal;
+
+/**
+ * Marker class used when parsing data that provides PMC participation data.
+ * <p>
+ * When using this class, pmcParticipation == null means "does not have any pmc participation", rather than "unknown".
+ * </p>
+ *
+ * @author apb@jhu.edu
+ */
+public class PMCSource extends Journal {
+
+    public PMCSource() {
+        super();
+    }
+
+    public PMCSource(Journal initial) {
+        super(initial);
+    }
+}

--- a/pass-journal-loader-nih/src/test/java/org/dataconservancy/pass/loader/journal/nih/LoaderEngineTest.java
+++ b/pass-journal-loader-nih/src/test/java/org/dataconservancy/pass/loader/journal/nih/LoaderEngineTest.java
@@ -75,7 +75,7 @@ public class LoaderEngineTest {
 
         when(client.readResource(eq(existing.getId()), eq(Journal.class))).thenReturn(existing);
 
-        final Journal toAdd = new Journal();
+        final Journal toAdd = new PMCSource();
         toAdd.setIssns(existing.getIssns());
         toAdd.setName(existing.getName());
         toAdd.setPmcParticipation(PmcParticipation.A);
@@ -103,7 +103,7 @@ public class LoaderEngineTest {
 
         when(client.readResource(eq(existing.getId()), eq(Journal.class))).thenReturn(existing);
 
-        final Journal toAdd = new Journal();
+        final Journal toAdd = new PMCSource();
         toAdd.setIssns(existing.getIssns());
         toAdd.setName(existing.getName());
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <pass.java.client.version>0.5.2</pass.java.client.version>
 
     <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
-    <docker-maven-plugin.version>0.28.0</docker-maven-plugin.version>
+    <docker-maven-plugin.version>0.27.2</docker-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-failsafe-plugin.version>2.22.1</maven-failsafe-plugin.version>


### PR DESCRIPTION
If an existing repository has ISSNs like `1234-567` instead of `PubType:1234-567`, the loader will NOT detect a match, and will add the journal anew.  This PR attempts to match and update existing records that lack the publication type.  

This PR also adds a `PMCSource` marker class that indicates whether the data provides a PMCParticipation value or not.  If not, the value of PMCSource will not be updated at all.  This is to prevent medline (which does not have PMC info) from clobbering pre-existing PMC participation values where records need to be updated only because of ISSN upgrades.