### PR TITLE
Upgrade log4j-to-slf4j and log4j-api to 2.15.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <commons.csv.version>1.6</commons.csv.version>
     <junit.version>4.12</junit.version>
     <logback.version>1.2.3</logback.version>
+    <log4j.version>2.15.0</log4j.version>
     <mockito.version>2.25.1</mockito.version>
     <pass.java.client.version>0.6.0</pass.java.client.version>
 
@@ -81,6 +82,18 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
         <version>${commons.csv.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
I haven't clarified the exposure of SL4J to the log4j RCE vulnerability, but this is a simple fix to insure use of log4j 2.15.0.